### PR TITLE
Squashed KeyEvent Branch

### DIFF
--- a/src/proj6BittingCerratoCohenEllmer/view/CodeTabs.fxml
+++ b/src/proj6BittingCerratoCohenEllmer/view/CodeTabs.fxml
@@ -16,4 +16,4 @@
          fx:id="tabPane" layoutX="14.0" layoutY="112.0"
          prefHeight="396.0" prefWidth="800.0" tabClosingPolicy="ALL_TABS"
          AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
-         AnchorPane.topAnchor="74.0" />
+         AnchorPane.topAnchor="74.0"/>


### PR DESCRIPTION
Set up key event listener for codeAreas
** Vim Command mode and Vim command lists reset if mouse is used! **
-> Is this a bug or how it is supposed to work @KitchenTable99 ?

While in command mode key presses are stored in an array for VIM command chaining.
Can exit command mode with i,I,a,A

Next:
- Stylize cursor/ indicate command mode
- Implement VIM methods in model to be called by Tab controller.